### PR TITLE
Add reskinnable idle framework core systems

### DIFF
--- a/Assets/Scripts/Core/Bootstrap.cs
+++ b/Assets/Scripts/Core/Bootstrap.cs
@@ -1,0 +1,359 @@
+using System.Collections.Generic;
+using IdleFramework.Core;
+using IdleFramework.Data;
+using IdleFramework.DI;
+using IdleFramework.Economy;
+using IdleFramework.Platform;
+using IdleFramework.Save;
+using IdleFramework.Utils;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace IdleFramework.Core
+{
+    /// <summary>
+    /// Bootstraps core services and creates a minimal runtime UI when none exists.
+    /// </summary>
+    public sealed class Bootstrap : MonoBehaviour
+    {
+        [SerializeField]
+        private float tickRate = 10f;
+
+        private TickManager _tickManager = null!;
+        private EconomyService _economy = null!;
+        private PrestigeService _prestige = null!;
+        private SaveService _saveService = null!;
+        private ContentDB _content = null!;
+        private readonly Dictionary<string, Text> _currencyLabels = new Dictionary<string, Text>();
+        private readonly List<GeneratorView> _generatorViews = new List<GeneratorView>();
+        private readonly List<UpgradeView> _upgradeViews = new List<UpgradeView>();
+        private Text _prestigeLabel = null!;
+        private Button _prestigeButton = null!;
+
+        private void Awake()
+        {
+            DontDestroyOnLoad(gameObject);
+
+            var locator = new ServiceLocator();
+            ServiceLocator.SetLocator(locator);
+
+            var skinName = PlayerPrefs.GetString("skinName", "Classic");
+            _content = new ContentDB();
+            _content.LoadSkin(skinName);
+
+            var timeProvider = new SystemTimeProvider();
+            locator.Register<ITimeProvider>(timeProvider);
+
+            _tickManager = gameObject.AddComponent<TickManager>();
+            _tickManager.SetTickRate(tickRate);
+
+            _economy = new EconomyService(_content);
+            _prestige = new PrestigeService(_economy, _content, timeProvider);
+            _saveService = new SaveService(_content, _economy, _prestige, timeProvider);
+
+            locator.Register(_tickManager);
+            locator.Register(_economy);
+            locator.Register(_prestige);
+            locator.Register(_saveService);
+            locator.Register(_content);
+
+            locator.Register(CreatePlatformServices());
+
+            _tickManager.OnTick += HandleTick;
+            _economy.OnStateChanged += RefreshUi;
+        }
+
+        private void Start()
+        {
+            _saveService.Load();
+            EnsureRuntimeUi();
+            RefreshUi();
+        }
+
+        private void OnDestroy()
+        {
+            if (_tickManager != null)
+            {
+                _tickManager.OnTick -= HandleTick;
+            }
+
+            if (_economy != null)
+            {
+                _economy.OnStateChanged -= RefreshUi;
+            }
+        }
+
+        private void HandleTick(float delta)
+        {
+            _economy.Tick(delta);
+            _saveService.Update(delta);
+        }
+
+        private void EnsureRuntimeUi()
+        {
+            if (FindObjectOfType<Canvas>() != null)
+            {
+                return;
+            }
+
+            var canvasGo = new GameObject("RuntimeCanvas");
+            var canvas = canvasGo.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvasGo.AddComponent<CanvasScaler>().uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            canvasGo.AddComponent<GraphicRaycaster>();
+
+            if (FindObjectOfType<EventSystem>() == null)
+            {
+                var es = new GameObject("EventSystem");
+                es.AddComponent<EventSystem>();
+                es.AddComponent<StandaloneInputModule>();
+            }
+
+            var root = new GameObject("HUD");
+            root.transform.SetParent(canvas.transform, false);
+            var rootLayout = root.AddComponent<VerticalLayoutGroup>();
+            rootLayout.spacing = 12;
+            rootLayout.padding = new RectOffset(12, 12, 12, 12);
+
+            BuildCurrenciesPanel(root.transform);
+            BuildGeneratorsPanel(root.transform);
+            BuildUpgradesPanel(root.transform);
+            BuildPrestigePanel(root.transform);
+        }
+
+        private void BuildCurrenciesPanel(Transform parent)
+        {
+            var panel = CreatePanel(parent, "Currencies");
+            foreach (var currency in _content.Currencies.Values)
+            {
+                var text = CreateText(panel.transform, $"{currency.Name}: 0");
+                _currencyLabels[currency.Id] = text;
+            }
+        }
+
+        private void BuildGeneratorsPanel(Transform parent)
+        {
+            var panel = CreatePanel(parent, "Generators");
+            foreach (var generator in _content.Generators.Values)
+            {
+                var card = new GameObject(generator.Name);
+                card.transform.SetParent(panel.transform, false);
+                var layout = card.AddComponent<HorizontalLayoutGroup>();
+                layout.spacing = 8;
+                layout.childForceExpandHeight = false;
+                layout.childForceExpandWidth = false;
+
+                var nameText = CreateText(card.transform, generator.Name);
+                nameText.alignment = TextAnchor.MiddleLeft;
+
+                var levelText = CreateText(card.transform, "Lv 0");
+                levelText.alignment = TextAnchor.MiddleLeft;
+
+                var costText = CreateText(card.transform, "Cost: 0");
+                costText.alignment = TextAnchor.MiddleLeft;
+
+                var buttonObj = new GameObject("BuyButton");
+                buttonObj.transform.SetParent(card.transform, false);
+                var image = buttonObj.AddComponent<Image>();
+                image.color = new Color(0.2f, 0.6f, 0.2f, 1f);
+                var button = buttonObj.AddComponent<Button>();
+                var layoutElement = buttonObj.AddComponent<LayoutElement>();
+                layoutElement.preferredWidth = 90;
+                layoutElement.preferredHeight = 36;
+                var buttonText = CreateText(buttonObj.transform, "Buy");
+                buttonText.alignment = TextAnchor.MiddleCenter;
+
+                var id = generator.Id;
+                button.onClick.AddListener(() =>
+                {
+                    if (_economy.TryBuyGeneratorLevel(id, out _))
+                    {
+                        RefreshUi();
+                    }
+                });
+
+                _generatorViews.Add(new GeneratorView
+                {
+                    Id = generator.Id,
+                    Level = levelText,
+                    Cost = costText,
+                    Button = button
+                });
+            }
+        }
+
+        private void BuildUpgradesPanel(Transform parent)
+        {
+            var panel = CreatePanel(parent, "Upgrades");
+            foreach (var upgrade in _content.Upgrades.Values)
+            {
+                var row = new GameObject(upgrade.Name);
+                row.transform.SetParent(panel.transform, false);
+                var layout = row.AddComponent<HorizontalLayoutGroup>();
+                layout.spacing = 8;
+
+                var label = CreateText(row.transform, upgrade.Name);
+                label.alignment = TextAnchor.MiddleLeft;
+
+                var buttonObj = new GameObject("BuyButton");
+                buttonObj.transform.SetParent(row.transform, false);
+                var image = buttonObj.AddComponent<Image>();
+                image.color = new Color(0.2f, 0.4f, 0.6f, 1f);
+                var button = buttonObj.AddComponent<Button>();
+                var layoutElement = buttonObj.AddComponent<LayoutElement>();
+                layoutElement.preferredWidth = 90;
+                layoutElement.preferredHeight = 36;
+                var buttonText = CreateText(buttonObj.transform, "Buy");
+                buttonText.alignment = TextAnchor.MiddleCenter;
+
+                var id = upgrade.Id;
+                button.onClick.AddListener(() =>
+                {
+                    if (_economy.TryBuyUpgrade(id, out _))
+                    {
+                        RefreshUi();
+                    }
+                });
+
+                _upgradeViews.Add(new UpgradeView
+                {
+                    Id = upgrade.Id,
+                    Label = label,
+                    Button = button
+                });
+            }
+        }
+
+        private void BuildPrestigePanel(Transform parent)
+        {
+            var panel = CreatePanel(parent, "Prestige");
+            _prestigeLabel = CreateText(panel.transform, "Prestige: 0");
+
+            var buttonObj = new GameObject("PrestigeButton");
+            buttonObj.transform.SetParent(panel.transform, false);
+            var image = buttonObj.AddComponent<Image>();
+            image.color = new Color(0.6f, 0.2f, 0.2f, 1f);
+            _prestigeButton = buttonObj.AddComponent<Button>();
+            var layout = buttonObj.AddComponent<LayoutElement>();
+            layout.preferredWidth = 120;
+            layout.preferredHeight = 40;
+            var text = CreateText(buttonObj.transform, "Prestige");
+            text.alignment = TextAnchor.MiddleCenter;
+
+            _prestigeButton.onClick.AddListener(() =>
+            {
+                var earned = _prestige.PerformPrestige();
+                if (earned > 0)
+                {
+                    _saveService.Save();
+                    RefreshUi();
+                }
+            });
+        }
+
+        private GameObject CreatePanel(Transform parent, string title)
+        {
+            var panel = new GameObject(title + "Panel");
+            panel.transform.SetParent(parent, false);
+            var layout = panel.AddComponent<VerticalLayoutGroup>();
+            layout.spacing = 6;
+            CreateText(panel.transform, title).fontStyle = FontStyle.Bold;
+            return panel;
+        }
+
+        private Text CreateText(Transform parent, string text)
+        {
+            var go = new GameObject("Text");
+            go.transform.SetParent(parent, false);
+            var uiText = go.AddComponent<Text>();
+            uiText.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+            uiText.text = text;
+            uiText.color = Color.white;
+            uiText.fontSize = 18;
+            return uiText;
+        }
+
+        private void RefreshUi()
+        {
+            UpdateCurrencies();
+            UpdateGenerators();
+            UpdateUpgrades();
+            UpdatePrestige();
+        }
+
+        private void UpdateCurrencies()
+        {
+            foreach (var kvp in _currencyLabels)
+            {
+                var balance = _economy.Balances.TryGetValue(kvp.Key, out var value) ? value : 0;
+                kvp.Value.text = $"{_content.Currencies[kvp.Key].Name}: {NumberFormatter.Format(balance)}";
+            }
+        }
+
+        private void UpdateGenerators()
+        {
+            foreach (var view in _generatorViews)
+            {
+                var state = _economy.Generators[view.Id];
+                view.Level.text = $"Lv {state.Level}";
+                view.Cost.text = $"Cost: {NumberFormatter.Format(_economy.GetNextGeneratorCost(view.Id))}";
+                view.Button.interactable = _economy.CanBuyGeneratorLevel(view.Id, out _);
+            }
+        }
+
+        private void UpdateUpgrades()
+        {
+            foreach (var view in _upgradeViews)
+            {
+                var upgrade = _content.Upgrades[view.Id];
+                var purchased = _economy.PurchasedUpgrades.Contains(view.Id);
+                view.Label.text = $"{upgrade.Name} ({NumberFormatter.Format(upgrade.Price)})" + (purchased ? " [Owned]" : string.Empty);
+                view.Button.interactable = !purchased && _economy.CanPurchaseUpgrade(view.Id, out _);
+            }
+        }
+
+        private void UpdatePrestige()
+        {
+            var preview = _prestige.PreviewPrestige();
+            _prestigeLabel.text = $"Prestige: {_prestige.PrestigeCurrency} (+{preview})";
+            _prestigeButton.interactable = preview > 0;
+        }
+
+        private IPlatformServices CreatePlatformServices()
+        {
+#if UNITY_STANDALONE
+            return new Platform.SteamServicesStub();
+#elif UNITY_ANDROID || UNITY_IOS
+            return new Platform.MobileServicesStub();
+#else
+            return new PlatformServicesNull();
+#endif
+        }
+
+        private sealed class PlatformServicesNull : IPlatformServices
+        {
+            public void UnlockAchievement(string id) { }
+            public void ReportStat(string id, double value) { }
+            public void ShowAchievements() { }
+            public void RequestCloudSaveSync() { }
+            public void ShowStorePage(string productId) { }
+            public void ShowAd(string placementId) { }
+        }
+
+        private sealed class GeneratorView
+        {
+            public string Id = string.Empty;
+            public Text Level = null!;
+            public Text Cost = null!;
+            public Button Button = null!;
+        }
+
+        private sealed class UpgradeView
+        {
+            public string Id = string.Empty;
+            public Text Label = null!;
+            public Button Button = null!;
+        }
+    }
+}

--- a/Assets/Scripts/Core/TickManager.cs
+++ b/Assets/Scripts/Core/TickManager.cs
@@ -1,0 +1,73 @@
+using System;
+using UnityEngine;
+
+namespace IdleFramework.Core
+{
+    /// <summary>
+    /// Provides a fixed-step simulation loop for idle gameplay services.
+    /// </summary>
+    public sealed class TickManager : MonoBehaviour
+    {
+        private const float DefaultTickRate = 10f;
+        private float _accumulator;
+        private bool _isRunning;
+
+        /// <summary>
+        /// Occurs when the simulation advances by one fixed step.
+        /// </summary>
+        public event Action<float>? OnTick;
+
+        /// <summary>
+        /// Gets or sets the number of ticks executed per second.
+        /// </summary>
+        public float TickRate { get; private set; } = DefaultTickRate;
+
+        private void Awake()
+        {
+            Resume();
+        }
+
+        private void Update()
+        {
+            if (!_isRunning)
+            {
+                return;
+            }
+
+            var delta = Time.unscaledDeltaTime;
+            _accumulator += delta;
+            var step = 1f / Mathf.Max(1f, TickRate);
+
+            while (_accumulator >= step)
+            {
+                _accumulator -= step;
+                OnTick?.Invoke(step);
+            }
+        }
+
+        /// <summary>
+        /// Adjusts the tick rate at runtime.
+        /// </summary>
+        /// <param name="ticksPerSecond">Desired ticks per second.</param>
+        public void SetTickRate(float ticksPerSecond)
+        {
+            TickRate = Mathf.Max(0.1f, ticksPerSecond);
+        }
+
+        /// <summary>
+        /// Pauses simulation ticks.
+        /// </summary>
+        public void Pause()
+        {
+            _isRunning = false;
+        }
+
+        /// <summary>
+        /// Resumes simulation ticks.
+        /// </summary>
+        public void Resume()
+        {
+            _isRunning = true;
+        }
+    }
+}

--- a/Assets/Scripts/Core/TimeProvider.cs
+++ b/Assets/Scripts/Core/TimeProvider.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace IdleFramework.Core
+{
+    /// <summary>
+    /// Abstraction for retrieving the current UTC time.
+    /// </summary>
+    public interface ITimeProvider
+    {
+        /// <summary>
+        /// Gets the current UTC timestamp.
+        /// </summary>
+        DateTimeOffset UtcNow { get; }
+    }
+
+    /// <summary>
+    /// Default implementation that reads from <see cref="DateTimeOffset.UtcNow"/>.
+    /// </summary>
+    public sealed class SystemTimeProvider : ITimeProvider
+    {
+        /// <inheritdoc />
+        public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
+    }
+}

--- a/Assets/Scripts/DI/ServiceLocator.cs
+++ b/Assets/Scripts/DI/ServiceLocator.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+
+namespace IdleFramework.DI
+{
+    /// <summary>
+    /// Lightweight service locator used to wire runtime services without relying on static singletons.
+    /// </summary>
+    public sealed class ServiceLocator
+    {
+        private readonly Dictionary<Type, object> _services = new Dictionary<Type, object>();
+
+        /// <summary>
+        /// Gets the active service locator for the application.
+        /// </summary>
+        public static ServiceLocator? Current { get; private set; }
+
+        /// <summary>
+        /// Assigns the globally accessible locator instance.
+        /// </summary>
+        /// <param name="locator">Locator to use.</param>
+        public static void SetLocator(ServiceLocator locator)
+        {
+            Current = locator ?? throw new ArgumentNullException(nameof(locator));
+        }
+
+        /// <summary>
+        /// Registers a service instance for later resolution.
+        /// </summary>
+        public void Register<TService>(TService instance) where TService : class
+        {
+            if (instance == null)
+            {
+                throw new ArgumentNullException(nameof(instance));
+            }
+
+            _services[typeof(TService)] = instance;
+        }
+
+        /// <summary>
+        /// Attempts to resolve a service of the given type.
+        /// </summary>
+        public bool TryResolve<TService>(out TService service) where TService : class
+        {
+            if (_services.TryGetValue(typeof(TService), out var value) && value is TService typed)
+            {
+                service = typed;
+                return true;
+            }
+
+            service = null!;
+            return false;
+        }
+
+        /// <summary>
+        /// Resolves a service of the requested type or throws if missing.
+        /// </summary>
+        public TService Resolve<TService>() where TService : class
+        {
+            if (TryResolve<TService>(out var service))
+            {
+                return service;
+            }
+
+            throw new InvalidOperationException($"Service of type {typeof(TService).Name} is not registered.");
+        }
+    }
+}

--- a/Assets/Scripts/Data/ContentDB.cs
+++ b/Assets/Scripts/Data/ContentDB.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using IdleFramework.Data.Models;
+using IdleFramework.Economy;
+using IdleFramework.Utils;
+
+namespace IdleFramework.Data
+{
+    /// <summary>
+    /// Loads and validates content definitions for a selected skin.
+    /// </summary>
+    public sealed class ContentDB
+    {
+        private readonly Dictionary<string, CurrencyDef> _currencies = new Dictionary<string, CurrencyDef>();
+        private readonly Dictionary<string, GeneratorDef> _generators = new Dictionary<string, GeneratorDef>();
+        private readonly Dictionary<string, UpgradeDef> _upgrades = new Dictionary<string, UpgradeDef>();
+        private readonly Dictionary<string, AchievementDef> _achievements = new Dictionary<string, AchievementDef>();
+        private readonly Dictionary<string, IUpgradeEffect> _upgradeEffects = new Dictionary<string, IUpgradeEffect>();
+        private readonly string _skinsRoot;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ContentDB"/> class.
+        /// </summary>
+        /// <param name="skinsRoot">Optional root path for skin JSON files.</param>
+        public ContentDB(string? skinsRoot = null)
+        {
+            _skinsRoot = skinsRoot ?? GetDefaultSkinRoot();
+        }
+
+        /// <summary>
+        /// Gets the active theme definition.
+        /// </summary>
+        public ThemeDef Theme { get; private set; } = new ThemeDef();
+
+        /// <summary>
+        /// Gets the current skin name.
+        /// </summary>
+        public string SkinName { get; private set; } = string.Empty;
+
+        /// <summary>
+        /// Gets all currencies keyed by identifier.
+        /// </summary>
+        public IReadOnlyDictionary<string, CurrencyDef> Currencies => _currencies;
+
+        /// <summary>
+        /// Gets all generator definitions keyed by identifier.
+        /// </summary>
+        public IReadOnlyDictionary<string, GeneratorDef> Generators => _generators;
+
+        /// <summary>
+        /// Gets all upgrade definitions keyed by identifier.
+        /// </summary>
+        public IReadOnlyDictionary<string, UpgradeDef> Upgrades => _upgrades;
+
+        /// <summary>
+        /// Gets all achievements keyed by identifier.
+        /// </summary>
+        public IReadOnlyDictionary<string, AchievementDef> Achievements => _achievements;
+
+        /// <summary>
+        /// Gets the default soft currency identifier.
+        /// </summary>
+        public string PrimaryCurrencyId => _currencies.Count > 0 ? _currencies.Values.First().Id : string.Empty;
+
+        /// <summary>
+        /// Retrieves the runtime effect associated with an upgrade.
+        /// </summary>
+        public IUpgradeEffect GetUpgradeEffect(string upgradeId)
+        {
+            if (_upgradeEffects.TryGetValue(upgradeId, out var effect))
+            {
+                return effect;
+            }
+
+            throw new KeyNotFoundException($"Upgrade effect not found for id {upgradeId}.");
+        }
+
+        /// <summary>
+        /// Loads a skin and validates its definitions.
+        /// </summary>
+        public void LoadSkin(string skinName)
+        {
+            if (string.IsNullOrWhiteSpace(skinName))
+            {
+                throw new ArgumentException("Skin name is required", nameof(skinName));
+            }
+
+            SkinName = skinName;
+            _currencies.Clear();
+            _generators.Clear();
+            _upgrades.Clear();
+            _achievements.Clear();
+            _upgradeEffects.Clear();
+
+            var skinFolder = Path.Combine(_skinsRoot, skinName);
+            if (!Directory.Exists(skinFolder))
+            {
+                throw new DirectoryNotFoundException($"Skin folder not found: {skinFolder}");
+            }
+
+            LoadCurrencies(Path.Combine(skinFolder, "currencies.json"));
+            LoadGenerators(Path.Combine(skinFolder, "generators.json"));
+            LoadUpgrades(Path.Combine(skinFolder, "upgrades.json"));
+            LoadAchievements(Path.Combine(skinFolder, "achievements.json"));
+            Theme = JsonUtils.DeserializeFromFile<ThemeDef>(Path.Combine(skinFolder, "theme.json"));
+
+            ApplyDefaults();
+            ValidateReferences();
+        }
+
+        private void LoadCurrencies(string path)
+        {
+            var items = JsonUtils.DeserializeFromFile<List<CurrencyDef>>(path);
+            foreach (var item in items)
+            {
+                _currencies[item.Id] = item;
+            }
+        }
+
+        private void LoadGenerators(string path)
+        {
+            var items = JsonUtils.DeserializeFromFile<List<GeneratorDef>>(path);
+            foreach (var item in items)
+            {
+                _generators[item.Id] = item;
+            }
+        }
+
+        private void LoadUpgrades(string path)
+        {
+            var items = JsonUtils.DeserializeFromFile<List<UpgradeDef>>(path);
+            foreach (var item in items)
+            {
+                _upgrades[item.Id] = item;
+                _upgradeEffects[item.Id] = UpgradeEffectFactory.Create(item.Effect);
+            }
+        }
+
+        private void LoadAchievements(string path)
+        {
+            var items = JsonUtils.DeserializeFromFile<List<AchievementDef>>(path);
+            foreach (var item in items)
+            {
+                _achievements[item.Id] = item;
+            }
+        }
+
+        private void ApplyDefaults()
+        {
+            foreach (var currency in _currencies.Values)
+            {
+                if (!Theme.StartingBalances.ContainsKey(currency.Id))
+                {
+                    Theme.StartingBalances[currency.Id] = currency.Start;
+                }
+            }
+        }
+
+        private void ValidateReferences()
+        {
+            foreach (var generator in _generators.Values)
+            {
+                if (!_currencies.ContainsKey(generator.CurrencyId))
+                {
+                    throw new InvalidDataException($"Generator {generator.Id} references missing currency {generator.CurrencyId}.");
+                }
+
+                if (!string.IsNullOrEmpty(generator.UnlockRequirement.CurrencyId) && !_currencies.ContainsKey(generator.UnlockRequirement.CurrencyId))
+                {
+                    throw new InvalidDataException($"Generator {generator.Id} unlock requires missing currency {generator.UnlockRequirement.CurrencyId}.");
+                }
+
+                if (!string.IsNullOrEmpty(generator.UnlockRequirement.GeneratorId) && !_generators.ContainsKey(generator.UnlockRequirement.GeneratorId))
+                {
+                    throw new InvalidDataException($"Generator {generator.Id} unlock requires missing generator {generator.UnlockRequirement.GeneratorId}.");
+                }
+            }
+
+            foreach (var upgrade in _upgrades.Values)
+            {
+                if (!string.IsNullOrEmpty(upgrade.Conditions.GeneratorId) && !_generators.ContainsKey(upgrade.Conditions.GeneratorId))
+                {
+                    throw new InvalidDataException($"Upgrade {upgrade.Id} references missing generator {upgrade.Conditions.GeneratorId}.");
+                }
+
+                if (!string.IsNullOrEmpty(upgrade.Conditions.CurrencyId) && !_currencies.ContainsKey(upgrade.Conditions.CurrencyId))
+                {
+                    throw new InvalidDataException($"Upgrade {upgrade.Id} references missing currency {upgrade.Conditions.CurrencyId}.");
+                }
+
+                if (!string.Equals(upgrade.Effect.Target, "all", StringComparison.OrdinalIgnoreCase) && !_generators.ContainsKey(upgrade.Effect.Target))
+                {
+                    throw new InvalidDataException($"Upgrade {upgrade.Id} effect targets missing generator {upgrade.Effect.Target}.");
+                }
+            }
+        }
+
+        private static string GetDefaultSkinRoot()
+        {
+#if UNITY_ANDROID || UNITY_IOS || UNITY_STANDALONE || UNITY_EDITOR
+            return Path.Combine(UnityEngine.Application.dataPath, "Skins");
+#else
+            return Path.Combine("Assets", "Skins");
+#endif
+        }
+    }
+}

--- a/Assets/Scripts/Data/Models/AchievementDef.cs
+++ b/Assets/Scripts/Data/Models/AchievementDef.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace IdleFramework.Data.Models
+{
+    /// <summary>
+    /// Achievement metadata for skins.
+    /// </summary>
+    public sealed class AchievementDef
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("desc")]
+        public string Description { get; set; } = string.Empty;
+    }
+}

--- a/Assets/Scripts/Data/Models/CurrencyDef.cs
+++ b/Assets/Scripts/Data/Models/CurrencyDef.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace IdleFramework.Data.Models
+{
+    /// <summary>
+    /// Currency definition loaded from JSON content.
+    /// </summary>
+    public sealed class CurrencyDef
+    {
+        /// <summary>
+        /// Unique identifier of the currency.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Display name.
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Starting balance for new saves.
+        /// </summary>
+        [JsonPropertyName("start")]
+        public double Start { get; set; }
+    }
+}

--- a/Assets/Scripts/Data/Models/GeneratorDef.cs
+++ b/Assets/Scripts/Data/Models/GeneratorDef.cs
@@ -1,0 +1,76 @@
+using System.Text.Json.Serialization;
+
+namespace IdleFramework.Data.Models
+{
+    /// <summary>
+    /// Describes a generator in the idle economy.
+    /// </summary>
+    public sealed class GeneratorDef
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("iconId")]
+        public string IconId { get; set; } = string.Empty;
+
+        [JsonPropertyName("currencyId")]
+        public string CurrencyId { get; set; } = string.Empty;
+
+        [JsonPropertyName("baseCost")]
+        public double BaseCost { get; set; }
+
+        [JsonPropertyName("costCurve")]
+        public CostCurveDef CostCurve { get; set; } = new CostCurveDef();
+
+        [JsonPropertyName("baseRatePerSec")]
+        public double BaseRatePerSec { get; set; }
+
+        [JsonPropertyName("unlockReq")]
+        public UnlockRequirementDef UnlockRequirement { get; set; } = new UnlockRequirementDef();
+
+        [JsonPropertyName("maxLevel")]
+        public int? MaxLevel { get; set; }
+    }
+
+    /// <summary>
+    /// Configuration for cost scaling.
+    /// </summary>
+    public sealed class CostCurveDef
+    {
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = "linear";
+
+        [JsonPropertyName("step")]
+        public double Step { get; set; } = 1.0;
+
+        [JsonPropertyName("growth")]
+        public double Growth { get; set; } = 1.07;
+
+        [JsonPropertyName("a")]
+        public double A { get; set; }
+
+        [JsonPropertyName("b")]
+        public double B { get; set; }
+    }
+
+    /// <summary>
+    /// Unlock conditions for a generator.
+    /// </summary>
+    public sealed class UnlockRequirementDef
+    {
+        [JsonPropertyName("currencyId")]
+        public string? CurrencyId { get; set; }
+
+        [JsonPropertyName("amount")]
+        public double Amount { get; set; }
+
+        [JsonPropertyName("generatorId")]
+        public string? GeneratorId { get; set; }
+
+        [JsonPropertyName("minLevel")]
+        public int MinLevel { get; set; }
+    }
+}

--- a/Assets/Scripts/Data/Models/ThemeDef.cs
+++ b/Assets/Scripts/Data/Models/ThemeDef.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace IdleFramework.Data.Models
+{
+    /// <summary>
+    /// Theme configuration describing presentation and meta tuning.
+    /// </summary>
+    public sealed class ThemeDef
+    {
+        [JsonPropertyName("primaryColor")]
+        public string PrimaryColor { get; set; } = "#FFFFFF";
+
+        [JsonPropertyName("fontId")]
+        public string FontId { get; set; } = "default";
+
+        [JsonPropertyName("sfxPackId")]
+        public string SfxPackId { get; set; } = string.Empty;
+
+        [JsonPropertyName("artAtlasId")]
+        public string ArtAtlasId { get; set; } = string.Empty;
+
+        [JsonPropertyName("prestigeFormula")]
+        public PrestigeFormulaDef PrestigeFormula { get; set; } = new PrestigeFormulaDef();
+
+        [JsonPropertyName("offlineCapHours")]
+        public double OfflineCapHours { get; set; } = 12d;
+
+        [JsonPropertyName("startingBalances")]
+        public Dictionary<string, double> StartingBalances { get; set; } = new Dictionary<string, double>();
+    }
+
+    /// <summary>
+    /// Parameters for the prestige conversion formula.
+    /// </summary>
+    public sealed class PrestigeFormulaDef
+    {
+        [JsonPropertyName("A")]
+        public double A { get; set; } = 1d;
+
+        [JsonPropertyName("B")]
+        public double B { get; set; } = 1d;
+    }
+}

--- a/Assets/Scripts/Data/Models/UpgradeDef.cs
+++ b/Assets/Scripts/Data/Models/UpgradeDef.cs
@@ -1,0 +1,70 @@
+using System.Text.Json.Serialization;
+
+namespace IdleFramework.Data.Models
+{
+    /// <summary>
+    /// Describes an upgrade purchasable by the player.
+    /// </summary>
+    public sealed class UpgradeDef
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("desc")]
+        public string Description { get; set; } = string.Empty;
+
+        [JsonPropertyName("price")]
+        public double Price { get; set; }
+
+        [JsonPropertyName("iconId")]
+        public string IconId { get; set; } = string.Empty;
+
+        [JsonPropertyName("conditions")]
+        public UpgradeConditionDef Conditions { get; set; } = new UpgradeConditionDef();
+
+        [JsonPropertyName("effect")]
+        public UpgradeEffectDef Effect { get; set; } = new UpgradeEffectDef();
+    }
+
+    /// <summary>
+    /// Conditions for unlocking an upgrade.
+    /// </summary>
+    public sealed class UpgradeConditionDef
+    {
+        [JsonPropertyName("generatorId")]
+        public string? GeneratorId { get; set; }
+
+        [JsonPropertyName("minLevel")]
+        public int MinLevel { get; set; }
+
+        [JsonPropertyName("currencyId")]
+        public string? CurrencyId { get; set; }
+
+        [JsonPropertyName("minTotal")]
+        public double MinTotal { get; set; }
+    }
+
+    /// <summary>
+    /// Raw definition of an upgrade effect.
+    /// </summary>
+    public sealed class UpgradeEffectDef
+    {
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = string.Empty;
+
+        [JsonPropertyName("target")]
+        public string Target { get; set; } = "all";
+
+        [JsonPropertyName("percent")]
+        public double Percent { get; set; }
+
+        [JsonPropertyName("amountPerSec")]
+        public double AmountPerSec { get; set; }
+
+        [JsonPropertyName("amount")]
+        public double Amount { get; set; }
+    }
+}

--- a/Assets/Scripts/Economy/CostCurves.cs
+++ b/Assets/Scripts/Economy/CostCurves.cs
@@ -1,0 +1,53 @@
+using System;
+using IdleFramework.Data.Models;
+
+namespace IdleFramework.Economy
+{
+    /// <summary>
+    /// Provides helpers for evaluating generator cost progression curves.
+    /// </summary>
+    public static class CostCurves
+    {
+        /// <summary>
+        /// Computes the cost for purchasing the next level given the current level.
+        /// </summary>
+        /// <param name="generator">Generator definition.</param>
+        /// <param name="currentLevel">Current level owned.</param>
+        /// <returns>Cost of the next level.</returns>
+        public static double GetCost(GeneratorDef generator, int currentLevel)
+        {
+            var n = Math.Max(0, currentLevel);
+            return generator.CostCurve.Type.ToLowerInvariant() switch
+            {
+                "linear" => Linear(generator.BaseCost, generator.CostCurve.Step, n),
+                "geometric" => Geometric(generator.BaseCost, generator.CostCurve.Growth, n),
+                "polynomial" => Polynomial(generator.BaseCost, generator.CostCurve.A, generator.CostCurve.B, n),
+                _ => throw new ArgumentOutOfRangeException(nameof(generator), $"Unknown cost curve {generator.CostCurve.Type}")
+            };
+        }
+
+        /// <summary>
+        /// Linear curve implementation <c>base + step * n</c>.
+        /// </summary>
+        public static double Linear(double baseCost, double step, int n)
+        {
+            return baseCost + step * n;
+        }
+
+        /// <summary>
+        /// Geometric curve implementation <c>base * growth^n</c>.
+        /// </summary>
+        public static double Geometric(double baseCost, double growth, int n)
+        {
+            return baseCost * Math.Pow(growth, n);
+        }
+
+        /// <summary>
+        /// Polynomial curve implementation <c>base * (1 + a*n + b*n^2)</c>.
+        /// </summary>
+        public static double Polynomial(double baseCost, double a, double b, int n)
+        {
+            return baseCost * (1d + a * n + b * n * n);
+        }
+    }
+}

--- a/Assets/Scripts/Economy/EconomyService.cs
+++ b/Assets/Scripts/Economy/EconomyService.cs
@@ -1,0 +1,604 @@
+using System;
+using System.Collections.Generic;
+using IdleFramework.Data;
+using IdleFramework.Data.Models;
+using IdleFramework.Save;
+
+namespace IdleFramework.Economy
+{
+    /// <summary>
+    /// Central service managing generator production, upgrades, and balances.
+    /// </summary>
+    public sealed class EconomyService
+    {
+        internal const string AllGeneratorsTarget = "all";
+
+        private readonly ContentDB _content;
+        private readonly Dictionary<string, GeneratorState> _generatorStates = new Dictionary<string, GeneratorState>();
+        private readonly Dictionary<string, double> _balances = new Dictionary<string, double>();
+        private readonly HashSet<string> _purchasedUpgrades = new HashSet<string>();
+        private readonly Dictionary<string, double> _multipliers = new Dictionary<string, double>();
+        private readonly Dictionary<string, double> _additives = new Dictionary<string, double>();
+        private readonly Dictionary<string, double> _costReductions = new Dictionary<string, double>();
+        private double _externalMultiplier = 1d;
+
+        /// <summary>
+        /// Occurs when any economy value changes.
+        /// </summary>
+        public event Action? OnStateChanged;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EconomyService"/> class.
+        /// </summary>
+        /// <param name="content">Content database.</param>
+        public EconomyService(ContentDB content)
+        {
+            _content = content ?? throw new ArgumentNullException(nameof(content));
+            foreach (var generator in content.Generators.Values)
+            {
+                _generatorStates[generator.Id] = new GeneratorState(generator);
+            }
+
+            foreach (var currency in content.Currencies.Values)
+            {
+                _balances[currency.Id] = content.Theme.StartingBalances.TryGetValue(currency.Id, out var start) ? start : currency.Start;
+            }
+        }
+
+        /// <summary>
+        /// Gets the total lifetime production across all generators.
+        /// </summary>
+        public double TotalLifetimeProduced { get; private set; }
+
+        /// <summary>
+        /// Gets current currency balances.
+        /// </summary>
+        public IReadOnlyDictionary<string, double> Balances => _balances;
+
+        /// <summary>
+        /// Gets generator runtime states.
+        /// </summary>
+        public IReadOnlyDictionary<string, GeneratorState> Generators => _generatorStates;
+
+        /// <summary>
+        /// Gets purchased upgrade identifiers.
+        /// </summary>
+        public IReadOnlyCollection<string> PurchasedUpgrades => _purchasedUpgrades;
+
+        /// <summary>
+        /// Sets a multiplier applied globally (e.g., from prestige).
+        /// </summary>
+        /// <param name="multiplier">Multiplier value.</param>
+        public void SetExternalGlobalMultiplier(double multiplier)
+        {
+            _externalMultiplier = Math.Max(0d, multiplier);
+        }
+
+        /// <summary>
+        /// Advances the economy simulation.
+        /// </summary>
+        /// <param name="deltaTime">Delta time in seconds.</param>
+        public void Tick(double deltaTime)
+        {
+            if (deltaTime <= 0)
+            {
+                return;
+            }
+
+            foreach (var state in _generatorStates.Values)
+            {
+                if (state.Level <= 0)
+                {
+                    continue;
+                }
+
+                var production = GetGeneratorProductionPerSec(state.Definition.Id) * deltaTime;
+                if (production <= 0)
+                {
+                    continue;
+                }
+
+                AddCurrency(state.Definition.CurrencyId, production);
+                state.LifetimeProduced += production;
+                TotalLifetimeProduced += production;
+            }
+
+            OnStateChanged?.Invoke();
+        }
+
+        /// <summary>
+        /// Adds currency without triggering validation.
+        /// </summary>
+        public void AddCurrency(string currencyId, double amount)
+        {
+            if (!_balances.ContainsKey(currencyId))
+            {
+                _balances[currencyId] = 0;
+            }
+
+            _balances[currencyId] += amount;
+        }
+
+        /// <summary>
+        /// Determines whether the next generator level can be purchased.
+        /// </summary>
+        public bool CanBuyGeneratorLevel(string generatorId, out string reason)
+        {
+            reason = string.Empty;
+            if (!_generatorStates.TryGetValue(generatorId, out var state))
+            {
+                reason = "Generator not found";
+                return false;
+            }
+
+            if (!IsGeneratorUnlocked(state.Definition))
+            {
+                reason = "Generator locked";
+                return false;
+            }
+
+            if (state.Definition.MaxLevel.HasValue && state.Level >= state.Definition.MaxLevel.Value)
+            {
+                reason = "Max level reached";
+                return false;
+            }
+
+            var cost = GetNextGeneratorCost(generatorId);
+            if (!HasCurrency(state.Definition.CurrencyId, cost))
+            {
+                reason = "Insufficient currency";
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Attempts to buy the next level of a generator.
+        /// </summary>
+        public bool TryBuyGeneratorLevel(string generatorId, out string reason)
+        {
+            if (!CanBuyGeneratorLevel(generatorId, out reason))
+            {
+                return false;
+            }
+
+            var state = _generatorStates[generatorId];
+            var cost = GetNextGeneratorCost(generatorId);
+            SpendCurrency(state.Definition.CurrencyId, cost);
+            state.Level++;
+            OnStateChanged?.Invoke();
+            return true;
+        }
+
+        /// <summary>
+        /// Gets the cost for the next generator level after reductions.
+        /// </summary>
+        public double GetNextGeneratorCost(string generatorId)
+        {
+            var state = _generatorStates[generatorId];
+            var baseCost = CostCurves.GetCost(state.Definition, state.Level);
+            var reductionMultiplier = GetCostReductionMultiplier(generatorId);
+            return baseCost * reductionMultiplier;
+        }
+
+        /// <summary>
+        /// Attempts to purchase an upgrade.
+        /// </summary>
+        public bool CanPurchaseUpgrade(string upgradeId, out string reason)
+        {
+            reason = string.Empty;
+            if (_purchasedUpgrades.Contains(upgradeId))
+            {
+                reason = "Already purchased";
+                return false;
+            }
+
+            if (!_content.Upgrades.TryGetValue(upgradeId, out var def))
+            {
+                reason = "Upgrade not found";
+                return false;
+            }
+
+            if (!MeetsConditions(def, out reason))
+            {
+                return false;
+            }
+
+            var currencyId = def.Conditions.CurrencyId ?? _content.PrimaryCurrencyId;
+            if (!HasCurrency(currencyId, def.Price))
+            {
+                reason = "Insufficient currency";
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Attempts to purchase an upgrade.
+        /// </summary>
+        public bool TryBuyUpgrade(string upgradeId, out string reason)
+        {
+            if (!CanPurchaseUpgrade(upgradeId, out reason))
+            {
+                return false;
+            }
+
+            var def = _content.Upgrades[upgradeId];
+            var currencyId = def.Conditions.CurrencyId ?? _content.PrimaryCurrencyId;
+            SpendCurrency(currencyId, def.Price);
+            _purchasedUpgrades.Add(upgradeId);
+            RebuildUpgradeModifiers();
+            OnStateChanged?.Invoke();
+            return true;
+        }
+
+        /// <summary>
+        /// Computes the production per second for the given generator.
+        /// </summary>
+        public double GetGeneratorProductionPerSec(string generatorId)
+        {
+            var state = _generatorStates[generatorId];
+            if (state.Level <= 0)
+            {
+                return 0;
+            }
+
+            var baseProduction = state.Definition.BaseRatePerSec * state.Level;
+            var multiplier = GetMultiplier(generatorId);
+            var additive = GetAdditive(generatorId);
+            return Math.Max(0, baseProduction * multiplier + additive);
+        }
+
+        /// <summary>
+        /// Computes total production per second across all generators.
+        /// </summary>
+        public double GetTotalProductionPerSec()
+        {
+            double total = 0;
+            foreach (var generator in _generatorStates.Keys)
+            {
+                total += GetGeneratorProductionPerSec(generator);
+            }
+
+            return total;
+        }
+
+        /// <summary>
+        /// Computes offline earnings for a time span.
+        /// </summary>
+        public OfflineEarningsResult ComputeOfflineEarnings(DateTimeOffset lastSaveUtc, DateTimeOffset nowUtc, double capHours)
+        {
+            var elapsedHours = (nowUtc - lastSaveUtc).TotalHours;
+            var clampedHours = Math.Max(0, Math.Min(elapsedHours, capHours));
+            var seconds = clampedHours * 3600d;
+            var result = new OfflineEarningsResult(clampedHours, seconds);
+
+            if (seconds <= 0)
+            {
+                return result;
+            }
+
+            foreach (var state in _generatorStates.Values)
+            {
+                var perSec = GetGeneratorProductionPerSec(state.Definition.Id);
+                if (perSec <= 0)
+                {
+                    continue;
+                }
+
+                var amount = perSec * seconds;
+                result.Add(state.Definition.CurrencyId, state.Definition.Id, amount);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Applies offline earnings to current balances.
+        /// </summary>
+        public void ApplyOfflineEarnings(OfflineEarningsResult result)
+        {
+            foreach (var currency in result.CurrencyEarnings)
+            {
+                AddCurrency(currency.Key, currency.Value);
+            }
+        }
+
+        /// <summary>
+        /// Resets runtime state while preserving upgrades.
+        /// </summary>
+        public void ResetProgress()
+        {
+            foreach (var state in _generatorStates.Values)
+            {
+                state.Level = 0;
+                state.LifetimeProduced = 0;
+            }
+
+            foreach (var key in _balances.Keys)
+            {
+                _balances[key] = _content.Theme.StartingBalances.TryGetValue(key, out var start) ? start : 0;
+            }
+
+            _purchasedUpgrades.Clear();
+            RebuildUpgradeModifiers();
+            TotalLifetimeProduced = 0;
+            OnStateChanged?.Invoke();
+        }
+
+        /// <summary>
+        /// Restores economy values from a save model.
+        /// </summary>
+        public void LoadState(SaveModel model)
+        {
+            if (model == null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
+            var keys = new List<string>(_balances.Keys);
+            foreach (var currency in keys)
+            {
+                _balances[currency] = model.Currencies.TryGetValue(currency, out var balance) ? balance : _balances[currency];
+            }
+
+            foreach (var extra in model.Currencies)
+            {
+                if (!_balances.ContainsKey(extra.Key))
+                {
+                    _balances[extra.Key] = extra.Value;
+                }
+            }
+
+            foreach (var pair in _generatorStates)
+            {
+                pair.Value.Level = model.Generators.TryGetValue(pair.Key, out var level) ? level : 0;
+                pair.Value.LifetimeProduced = model.LifetimePerGenerator.TryGetValue(pair.Key, out var lifetime) ? lifetime : 0;
+            }
+
+            _purchasedUpgrades.Clear();
+            foreach (var id in model.PurchasedUpgrades)
+            {
+                _purchasedUpgrades.Add(id);
+            }
+
+            RebuildUpgradeModifiers();
+            TotalLifetimeProduced = model.TotalLifetimeProduced;
+        }
+
+        internal void AddMultiplier(string target, double percent)
+        {
+            var key = NormalizeTarget(target);
+            var current = _multipliers.ContainsKey(key) ? _multipliers[key] : 1d;
+            current *= 1d + percent;
+            _multipliers[key] = current;
+        }
+
+        internal void AddAdditive(string target, double amountPerSec)
+        {
+            var key = NormalizeTarget(target);
+            var current = _additives.ContainsKey(key) ? _additives[key] : 0d;
+            _additives[key] = current + amountPerSec;
+        }
+
+        internal void AddCostReduction(string target, double percent)
+        {
+            var key = NormalizeTarget(target);
+            var current = _costReductions.ContainsKey(key) ? _costReductions[key] : 1d;
+            current *= Math.Max(0.0, 1d - percent);
+            _costReductions[key] = current;
+        }
+
+        private void RebuildUpgradeModifiers()
+        {
+            _multipliers.Clear();
+            _additives.Clear();
+            _costReductions.Clear();
+
+            var context = new UpgradeEffectContext(this);
+            foreach (var upgradeId in _purchasedUpgrades)
+            {
+                var effect = _content.GetUpgradeEffect(upgradeId);
+                effect.Apply(context);
+            }
+        }
+
+        private bool MeetsConditions(UpgradeDef def, out string reason)
+        {
+            reason = string.Empty;
+            var conditions = def.Conditions;
+            if (!string.IsNullOrEmpty(conditions.GeneratorId))
+            {
+                var state = _generatorStates[conditions.GeneratorId];
+                if (state.Level < conditions.MinLevel)
+                {
+                    reason = "Generator level too low";
+                    return false;
+                }
+            }
+
+            if (conditions.MinTotal > 0)
+            {
+                var currency = conditions.CurrencyId ?? _content.PrimaryCurrencyId;
+                if (GetCurrencyBalance(currency) < conditions.MinTotal)
+                {
+                    reason = "Insufficient total currency";
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private bool IsGeneratorUnlocked(GeneratorDef def)
+        {
+            var req = def.UnlockRequirement;
+            if (!string.IsNullOrEmpty(req.CurrencyId) && GetCurrencyBalance(req.CurrencyId) < req.Amount)
+            {
+                return false;
+            }
+
+            if (!string.IsNullOrEmpty(req.GeneratorId) && _generatorStates.TryGetValue(req.GeneratorId, out var state) && state.Level < req.MinLevel)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool HasCurrency(string currencyId, double amount)
+        {
+            return GetCurrencyBalance(currencyId) >= amount;
+        }
+
+        private double GetCurrencyBalance(string currencyId)
+        {
+            return _balances.TryGetValue(currencyId, out var value) ? value : 0d;
+        }
+
+        private void SpendCurrency(string currencyId, double amount)
+        {
+            if (!_balances.ContainsKey(currencyId))
+            {
+                _balances[currencyId] = 0;
+            }
+
+            _balances[currencyId] = Math.Max(0, _balances[currencyId] - amount);
+        }
+
+        private double GetMultiplier(string generatorId)
+        {
+            double value = 1d;
+            if (_multipliers.TryGetValue(AllGeneratorsTarget, out var global))
+            {
+                value *= global;
+            }
+
+            if (_multipliers.TryGetValue(generatorId, out var specific))
+            {
+                value *= specific;
+            }
+
+            return value * _externalMultiplier;
+        }
+
+        private double GetAdditive(string generatorId)
+        {
+            double value = 0d;
+            if (_additives.TryGetValue(AllGeneratorsTarget, out var global))
+            {
+                value += global;
+            }
+
+            if (_additives.TryGetValue(generatorId, out var specific))
+            {
+                value += specific;
+            }
+
+            return value;
+        }
+
+        private double GetCostReductionMultiplier(string generatorId)
+        {
+            double value = 1d;
+            if (_costReductions.TryGetValue(AllGeneratorsTarget, out var global))
+            {
+                value *= global;
+            }
+
+            if (_costReductions.TryGetValue(generatorId, out var specific))
+            {
+                value *= specific;
+            }
+
+            return value;
+        }
+
+        private static string NormalizeTarget(string target)
+        {
+            return string.IsNullOrEmpty(target) ? AllGeneratorsTarget : target;
+        }
+    }
+
+    /// <summary>
+    /// Represents runtime state for a generator.
+    /// </summary>
+    public sealed class GeneratorState
+    {
+        internal GeneratorState(GeneratorDef def)
+        {
+            Definition = def;
+        }
+
+        /// <summary>
+        /// Generator definition.
+        /// </summary>
+        public GeneratorDef Definition { get; }
+
+        /// <summary>
+        /// Current owned level.
+        /// </summary>
+        public int Level { get; set; }
+
+        /// <summary>
+        /// Total lifetime production from this generator.
+        /// </summary>
+        public double LifetimeProduced { get; set; }
+    }
+
+    /// <summary>
+    /// Result information for offline earnings calculations.
+    /// </summary>
+    public sealed class OfflineEarningsResult
+    {
+        internal OfflineEarningsResult(double hours, double seconds)
+        {
+            Hours = hours;
+            Seconds = seconds;
+        }
+
+        /// <summary>
+        /// Total offline hours applied.
+        /// </summary>
+        public double Hours { get; }
+
+        /// <summary>
+        /// Total offline seconds applied.
+        /// </summary>
+        public double Seconds { get; }
+
+        /// <summary>
+        /// Gets total currency earnings by currency id.
+        /// </summary>
+        public Dictionary<string, double> CurrencyEarnings { get; } = new Dictionary<string, double>();
+
+        /// <summary>
+        /// Gets total earnings breakdown per generator.
+        /// </summary>
+        public Dictionary<string, double> GeneratorBreakdown { get; } = new Dictionary<string, double>();
+
+        /// <summary>
+        /// Total amount earned across all currencies.
+        /// </summary>
+        public double TotalEarned { get; private set; }
+
+        internal void Add(string currencyId, string generatorId, double amount)
+        {
+            if (!CurrencyEarnings.ContainsKey(currencyId))
+            {
+                CurrencyEarnings[currencyId] = 0;
+            }
+
+            CurrencyEarnings[currencyId] += amount;
+            if (!GeneratorBreakdown.ContainsKey(generatorId))
+            {
+                GeneratorBreakdown[generatorId] = 0;
+            }
+
+            GeneratorBreakdown[generatorId] += amount;
+            TotalEarned += amount;
+        }
+    }
+}

--- a/Assets/Scripts/Economy/PrestigeService.cs
+++ b/Assets/Scripts/Economy/PrestigeService.cs
@@ -1,0 +1,100 @@
+using System;
+using IdleFramework.Core;
+using IdleFramework.Data;
+
+namespace IdleFramework.Economy
+{
+    /// <summary>
+    /// Handles prestige conversions and meta progression.
+    /// </summary>
+    public sealed class PrestigeService
+    {
+        private readonly EconomyService _economy;
+        private readonly ContentDB _content;
+        private readonly ITimeProvider _timeProvider;
+        private double _prestigeCurrency;
+
+        /// <summary>
+        /// Occurs after a prestige reset.
+        /// </summary>
+        public event Action<int>? OnPrestige;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PrestigeService"/> class.
+        /// </summary>
+        public PrestigeService(EconomyService economy, ContentDB content, ITimeProvider timeProvider)
+        {
+            _economy = economy;
+            _content = content;
+            UpdateMultiplier();
+            LastPrestigeUtc = timeProvider.UtcNow;
+            _timeProvider = timeProvider;
+        }
+
+        /// <summary>
+        /// Gets the accumulated prestige currency.
+        /// </summary>
+        public double PrestigeCurrency => _prestigeCurrency;
+
+        /// <summary>
+        /// Gets the timestamp of the last prestige action.
+        /// </summary>
+        public DateTimeOffset LastPrestigeUtc { get; private set; }
+
+        /// <summary>
+        /// Calculates prestige payout for the current progress.
+        /// </summary>
+        public int PreviewPrestige()
+        {
+            return CalculatePrestige(_economy.TotalLifetimeProduced);
+        }
+
+        /// <summary>
+        /// Executes prestige, resetting progress and awarding meta currency.
+        /// </summary>
+        public int PerformPrestige()
+        {
+            var earned = PreviewPrestige();
+            if (earned <= 0)
+            {
+                return 0;
+            }
+
+            _prestigeCurrency += earned;
+            _economy.ResetProgress();
+            UpdateMultiplier();
+            LastPrestigeUtc = _timeProvider.UtcNow;
+            OnPrestige?.Invoke(earned);
+            return earned;
+        }
+
+        /// <summary>
+        /// Converts total production into prestige currency.
+        /// </summary>
+        /// <param name="totalLifetimeProduced">Lifetime production value.</param>
+        /// <returns>Prestige payout.</returns>
+        public int CalculatePrestige(double totalLifetimeProduced)
+        {
+            var formula = _content.Theme.PrestigeFormula;
+            var safeB = Math.Max(1d, formula.B);
+            var value = formula.A * Math.Sqrt(Math.Max(0d, totalLifetimeProduced) / safeB);
+            return (int)Math.Floor(value);
+        }
+
+        private void UpdateMultiplier()
+        {
+            var multiplier = 1d + _prestigeCurrency * 0.05d;
+            _economy.SetExternalGlobalMultiplier(multiplier);
+        }
+
+        /// <summary>
+        /// Restores saved prestige state.
+        /// </summary>
+        public void LoadState(double prestigeCurrency, DateTimeOffset lastPrestigeUtc)
+        {
+            _prestigeCurrency = prestigeCurrency;
+            LastPrestigeUtc = lastPrestigeUtc;
+            UpdateMultiplier();
+        }
+    }
+}

--- a/Assets/Scripts/Economy/UpgradeEffect.cs
+++ b/Assets/Scripts/Economy/UpgradeEffect.cs
@@ -1,0 +1,131 @@
+using System;
+using IdleFramework.Data.Models;
+
+namespace IdleFramework.Economy
+{
+    /// <summary>
+    /// Applies upgrade bonuses to the aggregated economy state.
+    /// </summary>
+    public interface IUpgradeEffect
+    {
+        /// <summary>
+        /// Applies the effect to the provided context.
+        /// </summary>
+        /// <param name="context">Mutable context that accumulates modifiers.</param>
+        void Apply(UpgradeEffectContext context);
+    }
+
+    /// <summary>
+    /// Aggregates upgrade modifiers.
+    /// </summary>
+    public sealed class UpgradeEffectContext
+    {
+        internal UpgradeEffectContext(EconomyService service)
+        {
+            Service = service;
+        }
+
+        internal EconomyService Service { get; }
+
+        /// <summary>
+        /// Adds a multiplicative bonus for the supplied target.
+        /// </summary>
+        public void AddMultiplier(string target, double percent)
+        {
+            Service.AddMultiplier(target, percent);
+        }
+
+        /// <summary>
+        /// Adds an additive bonus for the supplied target.
+        /// </summary>
+        public void AddAdditive(string target, double amountPerSec)
+        {
+            Service.AddAdditive(target, amountPerSec);
+        }
+
+        /// <summary>
+        /// Adds a cost reduction modifier for the supplied target.
+        /// </summary>
+        public void AddCostReduction(string target, double percent)
+        {
+            Service.AddCostReduction(target, percent);
+        }
+    }
+
+    /// <summary>
+    /// Factory producing upgrade effect instances from definitions.
+    /// </summary>
+    public static class UpgradeEffectFactory
+    {
+        /// <summary>
+        /// Creates a runtime effect from the provided definition.
+        /// </summary>
+        public static IUpgradeEffect Create(UpgradeEffectDef def)
+        {
+            if (def == null)
+            {
+                throw new ArgumentNullException(nameof(def));
+            }
+
+            var type = def.Type?.ToLowerInvariant();
+            return type switch
+            {
+                "multiplier" => new MultiplierUpgradeEffect(def.Target, def.Percent),
+                "additive" => new AdditiveUpgradeEffect(def.Target, def.AmountPerSec != 0 ? def.AmountPerSec : def.Amount),
+                "costreduction" => new CostReductionUpgradeEffect(def.Target, def.Percent),
+                _ => throw new ArgumentOutOfRangeException(nameof(def), $"Unknown upgrade effect type '{def.Type}'.")
+            };
+        }
+    }
+
+    internal sealed class MultiplierUpgradeEffect : IUpgradeEffect
+    {
+        private readonly string _target;
+        private readonly double _percent;
+
+        public MultiplierUpgradeEffect(string target, double percent)
+        {
+            _target = string.IsNullOrEmpty(target) ? EconomyService.AllGeneratorsTarget : target;
+            _percent = percent;
+        }
+
+        public void Apply(UpgradeEffectContext context)
+        {
+            context.AddMultiplier(_target, _percent);
+        }
+    }
+
+    internal sealed class AdditiveUpgradeEffect : IUpgradeEffect
+    {
+        private readonly string _target;
+        private readonly double _amountPerSec;
+
+        public AdditiveUpgradeEffect(string target, double amountPerSec)
+        {
+            _target = string.IsNullOrEmpty(target) ? EconomyService.AllGeneratorsTarget : target;
+            _amountPerSec = amountPerSec;
+        }
+
+        public void Apply(UpgradeEffectContext context)
+        {
+            context.AddAdditive(_target, _amountPerSec);
+        }
+    }
+
+    internal sealed class CostReductionUpgradeEffect : IUpgradeEffect
+    {
+        private readonly string _target;
+        private readonly double _percent;
+
+        public CostReductionUpgradeEffect(string target, double percent)
+        {
+            _target = string.IsNullOrEmpty(target) ? EconomyService.AllGeneratorsTarget : target;
+            _percent = percent;
+        }
+
+        public void Apply(UpgradeEffectContext context)
+        {
+            context.AddCostReduction(_target, _percent);
+        }
+    }
+}

--- a/Assets/Scripts/Platform/IPlatformServices.cs
+++ b/Assets/Scripts/Platform/IPlatformServices.cs
@@ -1,0 +1,38 @@
+namespace IdleFramework.Platform
+{
+    /// <summary>
+    /// Abstract platform integrations used by the template.
+    /// </summary>
+    public interface IPlatformServices
+    {
+        /// <summary>
+        /// Unlocks an achievement by identifier.
+        /// </summary>
+        void UnlockAchievement(string id);
+
+        /// <summary>
+        /// Reports a numeric stat.
+        /// </summary>
+        void ReportStat(string id, double value);
+
+        /// <summary>
+        /// Displays the platform specific achievement UI.
+        /// </summary>
+        void ShowAchievements();
+
+        /// <summary>
+        /// Triggers a cloud save upload/download.
+        /// </summary>
+        void RequestCloudSaveSync();
+
+        /// <summary>
+        /// Opens an in-app purchase store page.
+        /// </summary>
+        void ShowStorePage(string productId);
+
+        /// <summary>
+        /// Shows an advertisement if supported.
+        /// </summary>
+        void ShowAd(string placementId);
+    }
+}

--- a/Assets/Scripts/Platform/MobileServicesStub.cs
+++ b/Assets/Scripts/Platform/MobileServicesStub.cs
@@ -1,0 +1,42 @@
+#if UNITY_ANDROID || UNITY_IOS
+using UnityEngine;
+
+namespace IdleFramework.Platform
+{
+    /// <summary>
+    /// Mobile platform stub logging all calls.
+    /// </summary>
+    public sealed class MobileServicesStub : IPlatformServices
+    {
+        public void UnlockAchievement(string id)
+        {
+            Debug.Log($"[Mobile] UnlockAchievement: {id}");
+        }
+
+        public void ReportStat(string id, double value)
+        {
+            Debug.Log($"[Mobile] ReportStat {id}={value}");
+        }
+
+        public void ShowAchievements()
+        {
+            Debug.Log("[Mobile] ShowAchievements");
+        }
+
+        public void RequestCloudSaveSync()
+        {
+            Debug.Log("[Mobile] Cloud save sync requested");
+        }
+
+        public void ShowStorePage(string productId)
+        {
+            Debug.Log($"[Mobile] ShowStorePage: {productId}");
+        }
+
+        public void ShowAd(string placementId)
+        {
+            Debug.Log($"[Mobile] ShowAd placeholder: {placementId}");
+        }
+    }
+}
+#endif

--- a/Assets/Scripts/Platform/SteamServicesStub.cs
+++ b/Assets/Scripts/Platform/SteamServicesStub.cs
@@ -1,0 +1,42 @@
+#if UNITY_STANDALONE
+using UnityEngine;
+
+namespace IdleFramework.Platform
+{
+    /// <summary>
+    /// Simple Steam platform stub that logs calls to the console.
+    /// </summary>
+    public sealed class SteamServicesStub : IPlatformServices
+    {
+        public void UnlockAchievement(string id)
+        {
+            Debug.Log($"[Steam] UnlockAchievement: {id}");
+        }
+
+        public void ReportStat(string id, double value)
+        {
+            Debug.Log($"[Steam] ReportStat {id}={value}");
+        }
+
+        public void ShowAchievements()
+        {
+            Debug.Log("[Steam] ShowAchievements");
+        }
+
+        public void RequestCloudSaveSync()
+        {
+            Debug.Log("[Steam] CloudSaveSync");
+        }
+
+        public void ShowStorePage(string productId)
+        {
+            Debug.Log($"[Steam] ShowStorePage: {productId}");
+        }
+
+        public void ShowAd(string placementId)
+        {
+            Debug.Log($"[Steam] ShowAd placeholder: {placementId}");
+        }
+    }
+}
+#endif

--- a/Assets/Scripts/Save/ISaveCipher.cs
+++ b/Assets/Scripts/Save/ISaveCipher.cs
@@ -1,0 +1,18 @@
+namespace IdleFramework.Save
+{
+    /// <summary>
+    /// Provides a hook for obfuscating save payloads.
+    /// </summary>
+    public interface ISaveCipher
+    {
+        /// <summary>
+        /// Encodes plaintext bytes.
+        /// </summary>
+        byte[] Encode(byte[] input);
+
+        /// <summary>
+        /// Decodes encoded bytes.
+        /// </summary>
+        byte[] Decode(byte[] input);
+    }
+}

--- a/Assets/Scripts/Save/SaveModel.cs
+++ b/Assets/Scripts/Save/SaveModel.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace IdleFramework.Save
+{
+    /// <summary>
+    /// Serializable save data container.
+    /// </summary>
+    public sealed class SaveModel
+    {
+        [JsonPropertyName("version")]
+        public int Version { get; set; } = 1;
+
+        [JsonPropertyName("lastSaveUtc")]
+        public DateTimeOffset LastSaveUtc { get; set; }
+
+        [JsonPropertyName("currencies")]
+        public Dictionary<string, double> Currencies { get; set; } = new Dictionary<string, double>();
+
+        [JsonPropertyName("generators")]
+        public Dictionary<string, int> Generators { get; set; } = new Dictionary<string, int>();
+
+        [JsonPropertyName("purchasedUpgrades")]
+        public List<string> PurchasedUpgrades { get; set; } = new List<string>();
+
+        [JsonPropertyName("lifetimePerGenerator")]
+        public Dictionary<string, double> LifetimePerGenerator { get; set; } = new Dictionary<string, double>();
+
+        [JsonPropertyName("totalLifetimeProduced")]
+        public double TotalLifetimeProduced { get; set; }
+
+        [JsonPropertyName("prestigeCurrency")]
+        public double PrestigeCurrency { get; set; }
+
+        [JsonPropertyName("lastPrestigeUtc")]
+        public DateTimeOffset LastPrestigeUtc { get; set; }
+    }
+}

--- a/Assets/Scripts/Save/SaveService.cs
+++ b/Assets/Scripts/Save/SaveService.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using IdleFramework.Core;
+using IdleFramework.Data;
+using IdleFramework.Economy;
+using IdleFramework.Utils;
+
+namespace IdleFramework.Save
+{
+    /// <summary>
+    /// Handles persistence of economy state to disk.
+    /// </summary>
+    public sealed class SaveService
+    {
+        private const string FileName = "idle_save.dat";
+        private readonly EconomyService _economy;
+        private readonly PrestigeService _prestige;
+        private readonly ITimeProvider _timeProvider;
+        private readonly ISaveCipher _cipher;
+        private readonly Dictionary<int, Func<SaveModel, SaveModel>> _migrations = new Dictionary<int, Func<SaveModel, SaveModel>>();
+        private readonly string _saveDirectory;
+        private readonly double _autoSaveInterval;
+        private double _accumulator;
+
+        /// <summary>
+        /// Gets the current save file path.
+        /// </summary>
+        public string SavePath => Path.Combine(_saveDirectory, FileName);
+
+        /// <summary>
+        /// Gets the current save version.
+        /// </summary>
+        public int CurrentVersion { get; } = 1;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SaveService"/> class.
+        /// </summary>
+        public SaveService(ContentDB content, EconomyService economy, PrestigeService prestige, ITimeProvider timeProvider, ISaveCipher? cipher = null, string? saveDirectory = null, double autoSaveIntervalSeconds = 30d)
+        {
+            if (content == null)
+            {
+                throw new ArgumentNullException(nameof(content));
+            }
+
+            _economy = economy;
+            _prestige = prestige;
+            _timeProvider = timeProvider;
+            _cipher = cipher ?? new XorSaveCipher("idle-template");
+            _saveDirectory = saveDirectory ?? GetDefaultDirectory();
+            _autoSaveInterval = autoSaveIntervalSeconds;
+            Directory.CreateDirectory(_saveDirectory);
+        }
+
+        /// <summary>
+        /// Registers a migration invoked when loading older saves.
+        /// </summary>
+        public void RegisterMigration(int version, Func<SaveModel, SaveModel> migration)
+        {
+            _migrations[version] = migration;
+        }
+
+        /// <summary>
+        /// Should be called regularly to handle autosaving.
+        /// </summary>
+        public void Update(double deltaTime)
+        {
+            _accumulator += deltaTime;
+            if (_accumulator < _autoSaveInterval)
+            {
+                return;
+            }
+
+            _accumulator = 0;
+            Save();
+        }
+
+        /// <summary>
+        /// Saves the current state to disk.
+        /// </summary>
+        public void Save()
+        {
+            var model = BuildModel();
+            var json = JsonUtils.Serialize(model);
+            var encoded = _cipher.Encode(System.Text.Encoding.UTF8.GetBytes(json));
+            File.WriteAllBytes(SavePath, encoded);
+        }
+
+        /// <summary>
+        /// Loads the current save file if present.
+        /// </summary>
+        public SaveModel Load()
+        {
+            if (!File.Exists(SavePath))
+            {
+                return new SaveModel { Version = CurrentVersion };
+            }
+
+            var encoded = File.ReadAllBytes(SavePath);
+            var json = System.Text.Encoding.UTF8.GetString(_cipher.Decode(encoded));
+            var model = JsonUtils.Deserialize<SaveModel>(json);
+            model = RunMigrations(model);
+            Apply(model);
+            return model;
+        }
+
+        /// <summary>
+        /// Applies a save model to runtime services.
+        /// </summary>
+        public void Apply(SaveModel model)
+        {
+            _economy.LoadState(model);
+            _prestige.LoadState(model.PrestigeCurrency, model.LastPrestigeUtc);
+        }
+
+        private SaveModel BuildModel()
+        {
+            var model = new SaveModel
+            {
+                Version = CurrentVersion,
+                LastSaveUtc = _timeProvider.UtcNow,
+                TotalLifetimeProduced = _economy.TotalLifetimeProduced,
+                PrestigeCurrency = _prestige.PrestigeCurrency,
+                LastPrestigeUtc = _prestige.LastPrestigeUtc
+            };
+
+            foreach (var currency in _economy.Balances)
+            {
+                model.Currencies[currency.Key] = currency.Value;
+            }
+
+            foreach (var pair in _economy.Generators)
+            {
+                model.Generators[pair.Key] = pair.Value.Level;
+                model.LifetimePerGenerator[pair.Key] = pair.Value.LifetimeProduced;
+            }
+
+            foreach (var upgrade in _economy.PurchasedUpgrades)
+            {
+                model.PurchasedUpgrades.Add(upgrade);
+            }
+
+            return model;
+        }
+
+        private SaveModel RunMigrations(SaveModel model)
+        {
+            var current = model;
+            while (current.Version < CurrentVersion)
+            {
+                if (_migrations.TryGetValue(current.Version, out var migration))
+                {
+                    current = migration(current);
+                }
+
+                current.Version++;
+            }
+
+            return current;
+        }
+
+        private static string GetDefaultDirectory()
+        {
+#if UNITY_ANDROID || UNITY_IOS || UNITY_STANDALONE || UNITY_EDITOR
+            return UnityEngine.Application.persistentDataPath;
+#else
+            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "IdleTemplate");
+#endif
+        }
+    }
+}

--- a/Assets/Scripts/Save/XorSaveCipher.cs
+++ b/Assets/Scripts/Save/XorSaveCipher.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Text;
+
+namespace IdleFramework.Save
+{
+    /// <summary>
+    /// Minimal XOR cipher used as a placeholder for production ready obfuscation.
+    /// </summary>
+    public sealed class XorSaveCipher : ISaveCipher
+    {
+        private readonly byte[] _key;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XorSaveCipher"/> class.
+        /// </summary>
+        public XorSaveCipher(string key)
+        {
+            if (string.IsNullOrEmpty(key))
+            {
+                throw new ArgumentException("Key must not be empty", nameof(key));
+            }
+
+            _key = Encoding.UTF8.GetBytes(key);
+        }
+
+        /// <inheritdoc />
+        public byte[] Encode(byte[] input)
+        {
+            return Transform(input);
+        }
+
+        /// <inheritdoc />
+        public byte[] Decode(byte[] input)
+        {
+            return Transform(input);
+        }
+
+        private byte[] Transform(byte[] input)
+        {
+            var output = new byte[input.Length];
+            for (var i = 0; i < input.Length; i++)
+            {
+                output[i] = (byte)(input[i] ^ _key[i % _key.Length]);
+            }
+
+            return output;
+        }
+    }
+}

--- a/Assets/Scripts/Scripts.asmdef
+++ b/Assets/Scripts/Scripts.asmdef
@@ -1,0 +1,13 @@
+{
+  "name": "IdleFramework.Scripts",
+  "rootNamespace": "IdleFramework",
+  "references": [],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "optionalUnityReferences": []
+}

--- a/Assets/Scripts/Utils/JsonUtils.cs
+++ b/Assets/Scripts/Utils/JsonUtils.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace IdleFramework.Utils
+{
+    /// <summary>
+    /// Helper methods for JSON serialization.
+    /// </summary>
+    public static class JsonUtils
+    {
+        private static readonly JsonSerializerOptions Options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true,
+            WriteIndented = true
+        };
+
+        /// <summary>
+        /// Serializes a value to JSON using shared options.
+        /// </summary>
+        public static string Serialize<T>(T value)
+        {
+            return JsonSerializer.Serialize(value, Options);
+        }
+
+        /// <summary>
+        /// Deserializes JSON text to the specified type.
+        /// </summary>
+        public static T Deserialize<T>(string json)
+        {
+            return JsonSerializer.Deserialize<T>(json, Options) ?? throw new InvalidDataException("Unable to deserialize JSON content.");
+        }
+
+        /// <summary>
+        /// Reads JSON content from disk and deserializes to the specified type.
+        /// </summary>
+        public static T DeserializeFromFile<T>(string path)
+        {
+            var text = File.ReadAllText(path);
+            return Deserialize<T>(text);
+        }
+    }
+}

--- a/Assets/Scripts/Utils/NumberFormatter.cs
+++ b/Assets/Scripts/Utils/NumberFormatter.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace IdleFramework.Utils
+{
+    /// <summary>
+    /// Formats large floating point values using short suffixes suitable for idle games.
+    /// </summary>
+    public static class NumberFormatter
+    {
+        private static readonly string[] Suffixes = BuildSuffixes();
+
+        /// <summary>
+        /// Formats the provided value with suffixes such as K, M, B or aa.
+        /// </summary>
+        /// <param name="value">Value to format.</param>
+        /// <returns>Human readable string.</returns>
+        public static string Format(double value)
+        {
+            if (double.IsNaN(value) || double.IsInfinity(value))
+            {
+                return "0";
+            }
+
+            var abs = Math.Abs(value);
+            if (abs < 1000d)
+            {
+                return value.ToString(abs >= 100d ? "0" : abs >= 10d ? "0.0" : "0.00");
+            }
+
+            var index = 0;
+            while (abs >= 1000d && index < Suffixes.Length)
+            {
+                value /= 1000d;
+                abs /= 1000d;
+                index++;
+            }
+
+            if (index == 0)
+            {
+                return value.ToString("0.00");
+            }
+
+            if (index > Suffixes.Length)
+            {
+                return value.ToString("0.###E+0");
+            }
+
+            var suffix = index - 1 < Suffixes.Length ? Suffixes[index - 1] : null;
+            if (suffix == null)
+            {
+                return value.ToString("0.###E+0");
+            }
+
+            return $"{value:0.00}{suffix}";
+        }
+
+        private static string[] BuildSuffixes()
+        {
+            var list = new List<string> { "K", "M", "B", "T" };
+            for (var first = 'a'; first <= 'z'; first++)
+            {
+                for (var second = 'a'; second <= 'z'; second++)
+                {
+                    list.Add(new string(new[] { first, second }));
+                }
+            }
+
+            return list.ToArray();
+        }
+    }
+}

--- a/Assets/Skins/Classic/achievements.json
+++ b/Assets/Skins/Classic/achievements.json
@@ -1,0 +1,4 @@
+[
+  { "id": "ach_first_buy", "name": "First Purchase", "desc": "Buy any generator once" },
+  { "id": "ach_factory_owner", "name": "Factory Owner", "desc": "Own 5 factories" }
+]

--- a/Assets/Skins/Classic/currencies.json
+++ b/Assets/Skins/Classic/currencies.json
@@ -1,0 +1,4 @@
+[
+  { "id": "soft", "name": "Cookies", "start": 10 },
+  { "id": "prestige", "name": "Stardust", "start": 0 }
+]

--- a/Assets/Skins/Classic/generators.json
+++ b/Assets/Skins/Classic/generators.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "gen_oven",
+    "name": "Oven",
+    "iconId": "oven",
+    "currencyId": "soft",
+    "baseCost": 15,
+    "costCurve": { "type": "geometric", "growth": 1.15 },
+    "baseRatePerSec": 0.2,
+    "unlockReq": { "currencyId": "soft", "amount": 0 }
+  },
+  {
+    "id": "gen_factory",
+    "name": "Factory",
+    "iconId": "factory",
+    "currencyId": "soft",
+    "baseCost": 100,
+    "costCurve": { "type": "geometric", "growth": 1.17 },
+    "baseRatePerSec": 2.0,
+    "unlockReq": { "generatorId": "gen_oven", "minLevel": 10 }
+  }
+]

--- a/Assets/Skins/Classic/theme.json
+++ b/Assets/Skins/Classic/theme.json
@@ -1,0 +1,9 @@
+{
+  "primaryColor": "#FFB000",
+  "fontId": "default",
+  "sfxPackId": "classic",
+  "artAtlasId": "classic_atlas",
+  "prestigeFormula": { "A": 1.0, "B": 5000.0 },
+  "offlineCapHours": 12,
+  "startingBalances": { "soft": 10, "prestige": 0 }
+}

--- a/Assets/Skins/Classic/upgrades.json
+++ b/Assets/Skins/Classic/upgrades.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "upg_hotter_ovens",
+    "name": "Hotter Ovens",
+    "desc": "Increase oven output",
+    "price": 100,
+    "iconId": "flame",
+    "conditions": { "generatorId": "gen_oven", "minLevel": 10 },
+    "effect": { "type": "multiplier", "target": "gen_oven", "percent": 0.25 }
+  },
+  {
+    "id": "upg_factory_efficiency",
+    "name": "Factory Efficiency",
+    "desc": "Factories run faster",
+    "price": 500,
+    "iconId": "gear",
+    "conditions": { "generatorId": "gen_factory", "minLevel": 5 },
+    "effect": { "type": "multiplier", "target": "gen_factory", "percent": 0.5 }
+  },
+  {
+    "id": "upg_universal_fans",
+    "name": "Universal Fans",
+    "desc": "All production boosted",
+    "price": 1200,
+    "iconId": "star",
+    "conditions": { "currencyId": "soft", "minTotal": 500 },
+    "effect": { "type": "multiplier", "target": "all", "percent": 0.15 }
+  }
+]

--- a/Assets/Skins/Neon/achievements.json
+++ b/Assets/Skins/Neon/achievements.json
@@ -1,0 +1,4 @@
+[
+  { "id": "ach_first_launch", "name": "First Launch", "desc": "Deploy your first drone" },
+  { "id": "ach_reactor_master", "name": "Reactor Master", "desc": "Stabilize five reactors" }
+]

--- a/Assets/Skins/Neon/currencies.json
+++ b/Assets/Skins/Neon/currencies.json
@@ -1,0 +1,4 @@
+[
+  { "id": "soft", "name": "Credits", "start": 20 },
+  { "id": "prestige", "name": "Flux", "start": 0 }
+]

--- a/Assets/Skins/Neon/generators.json
+++ b/Assets/Skins/Neon/generators.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "gen_drone",
+    "name": "Drone",
+    "iconId": "drone",
+    "currencyId": "soft",
+    "baseCost": 25,
+    "costCurve": { "type": "linear", "step": 10 },
+    "baseRatePerSec": 0.5,
+    "unlockReq": { "currencyId": "soft", "amount": 0 }
+  },
+  {
+    "id": "gen_reactor",
+    "name": "Reactor",
+    "iconId": "reactor",
+    "currencyId": "soft",
+    "baseCost": 250,
+    "costCurve": { "type": "polynomial", "a": 0.1, "b": 0.02 },
+    "baseRatePerSec": 3.5,
+    "unlockReq": { "generatorId": "gen_drone", "minLevel": 15 }
+  }
+]

--- a/Assets/Skins/Neon/theme.json
+++ b/Assets/Skins/Neon/theme.json
@@ -1,0 +1,9 @@
+{
+  "primaryColor": "#00FFC6",
+  "fontId": "digital",
+  "sfxPackId": "neon",
+  "artAtlasId": "neon_atlas",
+  "prestigeFormula": { "A": 1.2, "B": 6000.0 },
+  "offlineCapHours": 10,
+  "startingBalances": { "soft": 20, "prestige": 0 }
+}

--- a/Assets/Skins/Neon/upgrades.json
+++ b/Assets/Skins/Neon/upgrades.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "upg_drone_swarm",
+    "name": "Drone Swarm",
+    "desc": "Adds more drones",
+    "price": 180,
+    "iconId": "swarm",
+    "conditions": { "generatorId": "gen_drone", "minLevel": 12 },
+    "effect": { "type": "additive", "target": "gen_drone", "amountPerSec": 1.0 }
+  },
+  {
+    "id": "upg_reactor_shielding",
+    "name": "Reactor Shielding",
+    "desc": "Reactors work safer",
+    "price": 900,
+    "iconId": "shield",
+    "conditions": { "generatorId": "gen_reactor", "minLevel": 3 },
+    "effect": { "type": "multiplier", "target": "gen_reactor", "percent": 0.4 }
+  },
+  {
+    "id": "upg_energy_market",
+    "name": "Energy Market",
+    "desc": "Reduces generator costs",
+    "price": 1500,
+    "iconId": "market",
+    "conditions": { "currencyId": "soft", "minTotal": 1000 },
+    "effect": { "type": "costReduction", "target": "all", "percent": 0.1 }
+  }
+]

--- a/Assets/Tests/Runtime/EconomyTests.cs
+++ b/Assets/Tests/Runtime/EconomyTests.cs
@@ -1,0 +1,86 @@
+using System.IO;
+using IdleFramework.Data;
+using IdleFramework.Economy;
+using NUnit.Framework;
+
+namespace IdleFramework.Tests.Runtime
+{
+    public class EconomyTests
+    {
+        [Test]
+        public void LinearCost_FollowsFormula()
+        {
+            Assert.AreEqual(25d, CostCurves.Linear(10d, 5d, 3));
+        }
+
+        [Test]
+        public void GeometricCost_FollowsFormula()
+        {
+            Assert.AreEqual(80d, CostCurves.Geometric(10d, 2d, 3));
+        }
+
+        [Test]
+        public void PolynomialCost_FollowsFormula()
+        {
+            var expected = 10d * (1d + 0.1d * 4 + 0.01d * 16);
+            Assert.AreEqual(expected, CostCurves.Polynomial(10d, 0.1d, 0.01d, 4));
+        }
+
+        [Test]
+        public void Upgrades_MultiplierStackingApplied()
+        {
+            var content = LoadContent("Classic");
+            var economy = new EconomyService(content);
+            var oven = economy.Generators["gen_oven"];
+            oven.Level = 10;
+            economy.AddCurrency("soft", 5000);
+
+            Assert.IsTrue(economy.TryBuyUpgrade("upg_hotter_ovens", out _));
+            Assert.IsTrue(economy.TryBuyUpgrade("upg_universal_fans", out _));
+
+            var baseRate = content.Generators["gen_oven"].BaseRatePerSec * oven.Level;
+            var expected = baseRate * (1 + 0.25d) * (1 + 0.15d);
+            Assert.AreEqual(expected, economy.GetGeneratorProductionPerSec("gen_oven"), 1e-6);
+        }
+
+        [Test]
+        public void Upgrades_AdditiveAndCostReduction()
+        {
+            var content = LoadContent("Neon");
+            var economy = new EconomyService(content);
+            economy.Generators["gen_drone"].Level = 12;
+            economy.Generators["gen_reactor"].Level = 3;
+            economy.AddCurrency("soft", 10000);
+
+            Assert.IsTrue(economy.TryBuyUpgrade("upg_drone_swarm", out _));
+            Assert.IsTrue(economy.TryBuyUpgrade("upg_energy_market", out _));
+
+            var baseDrone = content.Generators["gen_drone"].BaseRatePerSec * 12;
+            var production = economy.GetGeneratorProductionPerSec("gen_drone");
+            Assert.AreEqual(baseDrone + 1.0d, production, 1e-6);
+
+            var baseCost = CostCurves.GetCost(content.Generators["gen_drone"], 12);
+            var discounted = economy.GetNextGeneratorCost("gen_drone");
+            Assert.AreEqual(baseCost * 0.9d, discounted, 1e-6);
+        }
+
+        private static ContentDB LoadContent(string skin)
+        {
+            var root = FindProjectRoot();
+            var db = new ContentDB(Path.Combine(root, "Assets", "Skins"));
+            db.LoadSkin(skin);
+            return db;
+        }
+
+        private static string FindProjectRoot()
+        {
+            var dir = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+            while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "Assets")))
+            {
+                dir = dir.Parent;
+            }
+
+            return dir?.FullName ?? Directory.GetCurrentDirectory();
+        }
+    }
+}

--- a/Assets/Tests/Runtime/OfflineEarningsTests.cs
+++ b/Assets/Tests/Runtime/OfflineEarningsTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using IdleFramework.Data;
+using IdleFramework.Economy;
+using NUnit.Framework;
+
+namespace IdleFramework.Tests.Runtime
+{
+    public class OfflineEarningsTests
+    {
+        [Test]
+        public void OfflineEarnings_NoElapsedTime()
+        {
+            var economy = CreateEconomy();
+            var now = DateTimeOffset.UtcNow;
+            var result = economy.ComputeOfflineEarnings(now, now, 12);
+            Assert.AreEqual(0d, result.TotalEarned);
+        }
+
+        [Test]
+        public void OfflineEarnings_PartialHour()
+        {
+            var economy = CreateEconomy();
+            economy.Generators["gen_oven"].Level = 5;
+            var start = DateTimeOffset.UnixEpoch;
+            var end = start.AddMinutes(30);
+            var result = economy.ComputeOfflineEarnings(start, end, 12);
+            Assert.AreEqual(0.2d * 5 * 1800d, result.TotalEarned, 1e-6);
+        }
+
+        [Test]
+        public void OfflineEarnings_Capped()
+        {
+            var economy = CreateEconomy();
+            economy.Generators["gen_oven"].Level = 5;
+            var start = DateTimeOffset.UnixEpoch;
+            var end = start.AddHours(20);
+            var result = economy.ComputeOfflineEarnings(start, end, 2);
+            Assert.AreEqual(0.2d * 5 * 7200d, result.TotalEarned, 1e-6);
+        }
+
+        [Test]
+        public void OfflineEarnings_MultipleGenerators()
+        {
+            var economy = CreateEconomy();
+            economy.Generators["gen_oven"].Level = 5;
+            economy.Generators["gen_factory"].Level = 2;
+            var start = DateTimeOffset.UnixEpoch;
+            var end = start.AddHours(1);
+            var result = economy.ComputeOfflineEarnings(start, end, 12);
+
+            var oven = 0.2d * 5 * 3600d;
+            var factory = 2.0d * 2 * 3600d;
+            Assert.AreEqual(oven + factory, result.TotalEarned, 1e-6);
+            Assert.AreEqual(oven, result.GeneratorBreakdown["gen_oven"], 1e-6);
+            Assert.AreEqual(factory, result.GeneratorBreakdown["gen_factory"], 1e-6);
+        }
+
+        private static EconomyService CreateEconomy()
+        {
+            var db = new ContentDB(Path.Combine(FindProjectRoot(), "Assets", "Skins"));
+            db.LoadSkin("Classic");
+            return new EconomyService(db);
+        }
+
+        private static string FindProjectRoot()
+        {
+            var dir = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+            while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "Assets")))
+            {
+                dir = dir.Parent;
+            }
+
+            return dir?.FullName ?? Directory.GetCurrentDirectory();
+        }
+    }
+}

--- a/Assets/Tests/Runtime/SaveServiceTests.cs
+++ b/Assets/Tests/Runtime/SaveServiceTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.IO;
+using System.Text;
+using IdleFramework.Core;
+using IdleFramework.Data;
+using IdleFramework.Economy;
+using IdleFramework.Save;
+using NUnit.Framework;
+
+namespace IdleFramework.Tests.Runtime
+{
+    public class SaveServiceTests
+    {
+        [Test]
+        public void SaveService_RoundTripPersistsState()
+        {
+            var tempDir = CreateTempDirectory();
+            var content = LoadContent("Classic");
+            var economy = new EconomyService(content);
+            var prestige = new PrestigeService(economy, content, new SystemTimeProvider());
+            var saveService = new SaveService(content, economy, prestige, new SystemTimeProvider(), saveDirectory: tempDir);
+
+            economy.Generators["gen_oven"].Level = 10;
+            economy.AddCurrency("soft", 1234);
+            economy.AddCurrency("prestige", 5);
+            economy.AddCurrency("soft", 1000);
+            Assert.IsTrue(economy.TryBuyUpgrade("upg_hotter_ovens", out _));
+
+            saveService.Save();
+
+            economy.ResetProgress();
+            prestige.LoadState(0, DateTimeOffset.UnixEpoch);
+
+            saveService.Load();
+
+            Assert.AreEqual(10, economy.Generators["gen_oven"].Level);
+            Assert.IsTrue(economy.PurchasedUpgrades.Contains("upg_hotter_ovens"));
+            Assert.Greater(economy.Balances["soft"], 0);
+        }
+
+        [Test]
+        public void SaveService_MigrationInvoked()
+        {
+            var tempDir = CreateTempDirectory();
+            var content = LoadContent("Classic");
+            var economy = new EconomyService(content);
+            var prestige = new PrestigeService(economy, content, new SystemTimeProvider());
+            var saveService = new SaveService(content, economy, prestige, new SystemTimeProvider(), saveDirectory: tempDir);
+
+            var cipher = new XorSaveCipher("idle-template");
+            var legacy = new SaveModel { Version = 0 };
+            var json = IdleFramework.Utils.JsonUtils.Serialize(legacy);
+            var bytes = cipher.Encode(Encoding.UTF8.GetBytes(json));
+            File.WriteAllBytes(Path.Combine(tempDir, "idle_save.dat"), bytes);
+
+            var invoked = false;
+            saveService.RegisterMigration(0, model =>
+            {
+                invoked = true;
+                model.Version = 1;
+                return model;
+            });
+
+            saveService.Load();
+            Assert.IsTrue(invoked);
+        }
+
+        private static string CreateTempDirectory()
+        {
+            var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(path);
+            return path;
+        }
+
+        private static ContentDB LoadContent(string skin)
+        {
+            var db = new ContentDB(Path.Combine(FindProjectRoot(), "Assets", "Skins"));
+            db.LoadSkin(skin);
+            return db;
+        }
+
+        private static string FindProjectRoot()
+        {
+            var dir = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+            while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "Assets")))
+            {
+                dir = dir.Parent;
+            }
+
+            return dir?.FullName ?? Directory.GetCurrentDirectory();
+        }
+    }
+}

--- a/Assets/Tests/Runtime/Tests.asmdef
+++ b/Assets/Tests/Runtime/Tests.asmdef
@@ -1,0 +1,17 @@
+{
+  "name": "IdleFramework.Tests",
+  "rootNamespace": "IdleFramework.Tests",
+  "references": [
+    "IdleFramework.Scripts"
+  ],
+  "includePlatforms": [
+    "Editor"
+  ],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": false,
+  "defineConstraints": [],
+  "optionalUnityReferences": []
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,69 @@
-# idle2
-idle game
+# Idle Framework Template
+
+This repository contains a data-driven idle/clicker template built for Unity 2022+. All gameplay logic lives in `Assets/Scripts` and content is authored via JSON skin files under `Assets/Skins`.
+
+## Getting Started
+
+1. Open the project with Unity 2022 or newer.
+2. Add the `Bootstrap` prefabless MonoBehaviour to an empty scene (or drop the script on an empty GameObject). At runtime the bootstrapper wires services, loads the active skin, and spawns a lightweight HUD if no canvas exists.
+
+## Switching Skins
+
+The active skin is stored in `PlayerPrefs` under the key `skinName`. You can change it from code by calling:
+
+```csharp
+PlayerPrefs.SetString("skinName", "Neon");
+PlayerPrefs.Save();
+```
+
+The next launch will load JSON from `Assets/Skins/Neon`. Duplicate one of the skin folders to author your own theme.
+
+## Content Authoring
+
+Each skin provides five JSON files:
+
+- `currencies.json` – list of currency ids, display names, and starting balances.
+- `generators.json` – generator definitions including cost curves, base production, and unlock requirements.
+- `upgrades.json` – upgrade metadata and effect payloads.
+- `achievements.json` – presentation-only achievement definitions.
+- `theme.json` – palette, font ids, prestige tuning, offline cap hours, and starting currency overrides.
+
+Example generator definition:
+
+```json
+{
+  "id": "gen_oven",
+  "name": "Oven",
+  "iconId": "oven",
+  "currencyId": "soft",
+  "baseCost": 15,
+  "costCurve": { "type": "geometric", "growth": 1.15 },
+  "baseRatePerSec": 0.2,
+  "unlockReq": { "currencyId": "soft", "amount": 0 }
+}
+```
+
+Add new generators/upgrades by appending entries to these arrays. Referential integrity is validated at load time so any missing ids will throw descriptive exceptions in the editor.
+
+## Runtime Architecture
+
+- **ServiceLocator** – minimal dependency container used by `Bootstrap` to register the `EconomyService`, `PrestigeService`, `SaveService`, and platform stubs.
+- **TickManager** – fixed step simulation (default 10 Hz) that drives production and autosaving.
+- **EconomyService** – tracks balances, generator levels, upgrade effects, and offline earnings.
+- **PrestigeService** – converts lifetime production into meta currency and exposes a global multiplier hook.
+- **SaveService** – JSON persistence with a pluggable cipher and simple migration pipeline.
+- **ContentDB** – loads JSON definitions for the current skin and exposes lookups for runtime systems.
+
+## Running Tests
+
+The template ships with edit mode runtime tests validating cost curves, upgrade effects, offline earnings, and save/load round-tripping. Run them from Unity's Test Runner (Window → General → Test Runner) with the **Edit Mode** tab selected.
+
+## Extending Numbers
+
+`NumberFormatter` currently formats `double` values with human friendly suffixes. To integrate arbitrary precision types (e.g., `BigDouble`), update the formatter and economy calculations to use the new numeric type, ensuring tests cover edge cases.
+
+## Autosave Location
+
+Saves are written to `Application.persistentDataPath/idle_save.dat` (or a platform-specific equivalent). Replace `XorSaveCipher` with your own implementation to integrate encryption or cloud sync.
+
+Enjoy reskinning and extending the template!


### PR DESCRIPTION
## Summary
- implement service bootstrap, tick management, content loading, and runtime UI wiring for a skin-driven idle template
- build economy, upgrade, prestige, offline earnings, and save systems with JSON-driven data models
- add sample Classic and Neon skins plus runtime tests covering curves, offline rewards, and save/load behavior

## Testing
- not run (Unity editor required)

------
https://chatgpt.com/codex/tasks/task_e_68cb1c31cb0c8322bdd1e78f4cf6c328